### PR TITLE
Update sensehat repo with makefile improvement and add readme 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.ko
+*.cmd
+*.mod
+*.mod.c
+Module.symvers
+modules.order

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,12 @@ build:
 
 clean:
 	make -C /lib/modules/$(shell uname -r)/build clean M=$(PWD)
+
+load: build
+	sudo modprobe sysimgblt
+	sudo modprobe sysfillrect
+	sudo modprobe syscopyarea
+	sudo modprobe fb_sys_fops
+	sudo insmod rpisense-core.ko
+	sudo insmod rpisense-js.ko
+	sudo insmod rpisense-fb.ko

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 obj-m += rpisense-core.o rpisense-js.o rpisense-fb.o
 
+.PHONY: build clean load
+
 build:
 	make -C /lib/modules/$(shell uname -r)/build modules M=$(PWD)
 

--- a/core.h
+++ b/core.h
@@ -16,8 +16,8 @@
 #ifndef __LINUX_MFD_RPISENSE_CORE_H_
 #define __LINUX_MFD_RPISENSE_CORE_H_
 
-#include <linux/mfd/rpisense/joystick.h>
-#include <linux/mfd/rpisense/framebuffer.h>
+#include "joystick.h"
+#include "framebuffer.h"
 
 /*
  * Register values.

--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,17 @@
+how to compile and load the sensehat drivers for raspberry pi 4 on fedora
+
+clone the repository to get a copy of the code on your device, and then code can be compiled by running
+
+`$ make`
+
+and the modules (and their dependancies) can be loaded with
+
+`$ make load`
+
+Note: the makefile simply depends on the kernel makefile and if the kernel source is not installed / downloaded on the device make will not even be able to compile the module.
+If you have built your own kernel from source that you are running, it should already be in the correct place such that you can skip this step,
+but the default fedora image I was testing this on did not come with its kernel source directory populated and so I had to install the following packages: 
+
+`$ sudo dnf install kernel-devel kernel-tools kernel-headers`
+
+Once those packages were installed the correct source files were loaded so that the makefile worked as intended

--- a/readme.md
+++ b/readme.md
@@ -15,3 +15,8 @@ but the default fedora image I was testing this on did not come with its kernel 
 `$ sudo dnf install kernel-devel kernel-tools kernel-headers`
 
 Once those packages were installed the correct source files were loaded so that the makefile worked as intended
+
+Final Note: The devices may not be properly detected even though the modules load correctly. I ran into this issue and it turns
+out that I had not enabled device tree for discovering the hardware. Once I turned it on the drivers worked as expected. To do this:
+Press escape during the boot process to get into the settings menu and then navigate to Device manager -> Raspberry Pi Configuration -> Advanced Configuration
+and make sure that System Table Selection is set to ACPI + Devicetree

--- a/rpisense-core.c
+++ b/rpisense-core.c
@@ -20,7 +20,7 @@
 #include <linux/init.h>
 #include <linux/i2c.h>
 #include <linux/platform_device.h>
-#include <linux/mfd/rpisense/core.h>
+#include "core.h"
 #include <linux/slab.h>
 
 static struct rpisense *rpisense;

--- a/rpisense-fb.c
+++ b/rpisense-fb.c
@@ -24,8 +24,8 @@
 #include <linux/fb.h>
 #include <linux/init.h>
 
-#include <linux/mfd/rpisense/framebuffer.h>
-#include <linux/mfd/rpisense/core.h>
+#include "framebuffer.h"
+#include "core.h"
 
 static bool lowlight;
 module_param(lowlight, bool, 0);

--- a/rpisense-js.c
+++ b/rpisense-js.c
@@ -15,8 +15,8 @@
 
 #include <linux/module.h>
 
-#include <linux/mfd/rpisense/joystick.h>
-#include <linux/mfd/rpisense/core.h>
+#include "joystick.h"
+#include "core.h"
 
 static struct rpisense *rpisense;
 static unsigned char keymap[5] = {KEY_DOWN, KEY_RIGHT, KEY_UP, KEY_ENTER, KEY_LEFT,};


### PR DESCRIPTION
I tweaked the source code so that when cloned it is suitable for compiling (this required changing the header includes to use a local path with quotes instead of a library include path with angle brackets) and added a rule to the Makefile such that `$ make load` will automatically compile and load the drivers which allows faster development. Finally I added a readme that explains how to get started with this repo.