### PR TITLE
Remove `static struct rpisense` from drivers

### DIFF
--- a/core.h
+++ b/core.h
@@ -39,7 +39,6 @@ struct rpisense {
 	struct rpisense_fb framebuffer;
 };
 
-struct rpisense *rpisense_get_dev(void);
 s32 rpisense_reg_read(struct rpisense *rpisense, int reg);
 int rpisense_reg_write(struct rpisense *rpisense, int reg, u16 val);
 int rpisense_block_write(struct rpisense *rpisense, const char *buf, int count);

--- a/rpisense-core.c
+++ b/rpisense-core.c
@@ -97,11 +97,6 @@ static int rpisense_remove(struct i2c_client *i2c)
 	return 0;
 }
 
-struct rpisense *rpisense_get_dev(void)
-{
-	return rpisense;
-}
-EXPORT_SYMBOL_GPL(rpisense_get_dev);
 
 s32 rpisense_reg_read(struct rpisense *rpisense, int reg)
 {

--- a/rpisense-core.c
+++ b/rpisense-core.c
@@ -23,8 +23,6 @@
 #include "core.h"
 #include <linux/slab.h>
 
-static struct rpisense *rpisense;
-
 static void rpisense_client_dev_register(struct rpisense *rpisense,
 					 const char *name,
 					 struct platform_device **pdev)
@@ -54,7 +52,7 @@ static int rpisense_probe(struct i2c_client *i2c,
 	int ret;
 	struct rpisense_js *rpisense_js;
 
-	rpisense = devm_kzalloc(&i2c->dev, sizeof(struct rpisense), GFP_KERNEL);
+	struct rpisense *rpisense = devm_kzalloc(&i2c->dev, sizeof *rpisense, GFP_KERNEL);
 	if (rpisense == NULL)
 		return -ENOMEM;
 

--- a/rpisense-fb.c
+++ b/rpisense-fb.c
@@ -31,8 +31,6 @@ static bool lowlight;
 module_param(lowlight, bool, 0);
 MODULE_PARM_DESC(lowlight, "Reduce LED matrix brightness to one third");
 
-static struct rpisense *rpisense;
-
 struct rpisense_fb_param {
 	char __iomem *vmem;
 	u8 *vmem_work;
@@ -118,6 +116,7 @@ static void rpisense_fb_imageblit(struct fb_info *info,
 static void rpisense_fb_deferred_io(struct fb_info *info,
 				struct list_head *pagelist)
 {
+	struct rpisense *rpisense = dev_get_drvdata(info->device->parent);
 	int i;
 	int j;
 	u8 *vmem_work = rpisense_fb_param.vmem_work;
@@ -196,10 +195,9 @@ static int rpisense_fb_probe(struct platform_device *pdev)
 {
 	struct fb_info *info;
 	int ret = -ENOMEM;
-	struct rpisense_fb *rpisense_fb;
 
-	rpisense = rpisense_get_dev();
-	rpisense_fb = &rpisense->framebuffer;
+	struct rpisense *rpisense = dev_get_drvdata(pdev->dev.parent);
+	struct rpisense_fb *rpisense_fb = &rpisense->framebuffer;
 
 	rpisense_fb_param.vmem = vzalloc(rpisense_fb_param.vmemsize);
 	if (!rpisense_fb_param.vmem)
@@ -251,6 +249,7 @@ err_malloc:
 
 static int rpisense_fb_remove(struct platform_device *pdev)
 {
+	struct rpisense *rpisense = dev_get_drvdata(pdev->dev.parent);
 	struct rpisense_fb *rpisense_fb = &rpisense->framebuffer;
 	struct fb_info *info = rpisense_fb->info;
 


### PR DESCRIPTION
Closes #14 for the time being. Even though the driver still does not support multiple devices removing this facet of the design makes the code cleaner and should make it raise less eyebrows. Multiple HATs are not supported on the raspberry pi anyways so it is not an issue.