### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 obj-m += rpisense-core.o rpisense-js.o rpisense-fb.o
 
-.PHONY: build clean load
+.PHONY: build clean load unload
 
 build:
 	make -C /lib/modules/$(shell uname -r)/build modules M=$(PWD)
@@ -16,3 +16,5 @@ load:
 	sudo insmod rpisense-core.ko
 	sudo insmod rpisense-js.ko
 	sudo insmod rpisense-fb.ko
+unload:
+	sudo rmmod rpisense_js rpisense_fb rpisense_core

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 clean:
 	make -C /lib/modules/$(shell uname -r)/build clean M=$(PWD)
 
-load: build
+load:
 	sudo modprobe sysimgblt
 	sudo modprobe sysfillrect
 	sudo modprobe syscopyarea


### PR DESCRIPTION
I added an `unload` rule for removing the kernel modules and tweaked the `load` rule. Having the `load` rule depend on the `build` rule meant that running `make load` would chug pretty hard on the rpi even if the code was already compiled since make would have to parse and execute the huge kernel makefile just to find out it had to do nothing. Downside is you now have to type two commands instead of one to compile and load, but upside is loading and unloading are both snappy.