### PR TITLE
revert includes to the local path for the sensehat repo

### DIFF
--- a/rpisense-core.c
+++ b/rpisense-core.c
@@ -20,7 +20,7 @@
 #include <linux/i2c.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
-#include <linux/mfd/rpisense.h>
+#include "rpisense.h"
 
 #define RPISENSE_DISPLAY		0x00
 #define RPISENSE_WAI			0xF0

--- a/rpisense-display.c
+++ b/rpisense-display.c
@@ -22,7 +22,7 @@
 #include <linux/platform_device.h>
 #include <linux/mod_devicetable.h>
 
-#include <linux/mfd/rpisense.h>
+#include "rpisense.h"
 
 #define GAMMA_SIZE sizeof_field(struct rpisense_display, gamma)
 #define VMEM_SIZE sizeof_field(struct rpisense_display, vmem)

--- a/rpisense-js.c
+++ b/rpisense-js.c
@@ -17,7 +17,7 @@
 #include <linux/gpio/consumer.h>
 #include <linux/platform_device.h>
 
-#include <linux/mfd/rpisense.h>
+#include "rpisense.h"
 
 static unsigned char keymap[] = {KEY_DOWN, KEY_RIGHT, KEY_UP, KEY_ENTER, KEY_LEFT,};
 


### PR DESCRIPTION
As part of the preparation for the RFC the files in the linux tree were changed to use the `#include <linux/mfd/rpisense.h>` header path, unfortunately those changes were back ported into the sensehat repo which means the code in master does not compile atm