### PR TITLE
change keycodes in sensehat-joystick

### DIFF
--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -19,7 +19,7 @@
 
 #include "sensehat.h"
 
-static unsigned char keymap[] = {KEY_DOWN, KEY_RIGHT, KEY_UP, KEY_ENTER, KEY_LEFT,};
+static unsigned keymap[] = {BTN_DPAD_DOWN, BTN_DPAD_RIGHT, BTN_DPAD_UP, BTN_SELECT, BTN_DPAD_LEFT,};
 
 static irqreturn_t sensehat_joystick_report(int n, void *cookie)
 {


### PR DESCRIPTION
as suggested by Nicolas on last RFC the PR updates the key codes emitted by the joystick when you move it. This breaks the `framebuffer_test` example (and there is no way to detect the button codes it emits with ncurses) but I can see that it is delivering events by running `hexdump -C /dev/input/event1`.