### PR TITLE
update code to use regmap instead of raw i2c

### DIFF
--- a/sensehat-core.c
+++ b/sensehat-core.c
@@ -142,15 +142,6 @@ static struct regmap_config sensehat_config = {
 	.readable_reg = sensehat_readable_register,
 };
 
-int sensehat_get_joystick_state(struct sensehat *sensehat)
-{
-	unsigned reg;
-	int ret = regmap_read(sensehat->regmap, SENSEHAT_KEYS, &reg);
-
-	return ret < 0 ? ret : reg;
-}
-EXPORT_SYMBOL_GPL(sensehat_get_joystick_state);
-
 int sensehat_update_display(struct sensehat *sensehat)
 {
 	int i, j, ret;

--- a/sensehat-core.c
+++ b/sensehat-core.c
@@ -142,28 +142,6 @@ static struct regmap_config sensehat_config = {
 	.readable_reg = sensehat_readable_register,
 };
 
-int sensehat_update_display(struct sensehat *sensehat)
-{
-	int i, j, ret;
-	struct sensehat_display *display = &sensehat->display;
-	sensehat_fb_t pixel_data;
-
-	for (i = 0; i < 8; ++i) {
-		for (j = 0; j < 8; ++j) {
-			pixel_data[i][0][j] = display->gamma[display->vmem[i][j].r];
-			pixel_data[i][1][j] = display->gamma[display->vmem[i][j].g];
-			pixel_data[i][2][j] = display->gamma[display->vmem[i][j].b];
-		}
-	}
-
-	ret = regmap_bulk_write(sensehat->regmap, SENSEHAT_DISPLAY,
-				pixel_data, sizeof(pixel_data));
-	if (ret < 0)
-		dev_err(sensehat->dev, "Update to 8x8 LED matrix display failed");
-	return ret;
-}
-EXPORT_SYMBOL_GPL(sensehat_update_display);
-
 static const struct i2c_device_id sensehat_i2c_id[] = {
 	{ "sensehat", 0 },
 	{ "rpi-sense", 0 },

--- a/sensehat-core.c
+++ b/sensehat-core.c
@@ -23,17 +23,6 @@
 #include <linux/regmap.h>
 #include "sensehat.h"
 
-//8x8 display with 3 color channels
-typedef u8 sensehat_fb_t[8][3][8];
-
-#define SENSEHAT_DISPLAY		0x00
-#define SENSEHAT_WAI			0xF0
-#define SENSEHAT_VER			0xF1
-#define SENSEHAT_KEYS			0xF2
-#define SENSEHAT_EE_WP			0xF3
-
-#define SENSEHAT_ID			's'
-
 static struct platform_device *
 sensehat_client_dev_register(struct sensehat *sensehat, const char *name);
 

--- a/sensehat-core.c
+++ b/sensehat-core.c
@@ -20,7 +20,11 @@
 #include <linux/i2c.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
+#include <linux/regmap.h>
 #include "sensehat.h"
+
+//8x8 display with 3 color channels
+typedef u8 sensehat_fb_t[8][3][8];
 
 #define SENSEHAT_DISPLAY		0x00
 #define SENSEHAT_WAI			0xF0
@@ -33,10 +37,13 @@
 static struct platform_device *
 sensehat_client_dev_register(struct sensehat *sensehat, const char *name);
 
+static struct regmap_config sensehat_config;
+
 static int sensehat_probe(struct i2c_client *i2c,
 			       const struct i2c_device_id *id)
 {
 	int ret;
+	unsigned reg;
 
 	struct sensehat *sensehat = devm_kzalloc(&i2c->dev, sizeof(*sensehat), GFP_KERNEL);
 
@@ -47,25 +54,34 @@ static int sensehat_probe(struct i2c_client *i2c,
 	sensehat->dev = &i2c->dev;
 	sensehat->i2c_client = i2c;
 
+	sensehat->regmap = devm_regmap_init_i2c(sensehat->i2c_client, &sensehat_config);
 
-	ret = i2c_smbus_read_byte_data(sensehat->i2c_client, SENSEHAT_WAI);
+	if(IS_ERR(sensehat->regmap)) {
+		dev_err(sensehat->dev, "Failed to initialize sensehat regmap");
+		return PTR_ERR(sensehat->regmap);
+	}
+
+
+	ret = regmap_read(sensehat->regmap, SENSEHAT_WAI, &reg);
 	if (ret < 0) {
 		dev_err(sensehat->dev, "failed to read from device");
 		return ret;
 	}
 
-	if (ret != SENSEHAT_ID) {
+	if (reg != SENSEHAT_ID) {
 		dev_err(sensehat->dev, "expected device ID %i, got %i",
 			SENSEHAT_ID, ret);
 		return -EINVAL;
 	}
 
-	ret = i2c_smbus_read_byte_data(sensehat->i2c_client, SENSEHAT_VER);
-	if (ret < 0)
+	ret = regmap_read(sensehat->regmap, SENSEHAT_VER, &reg);
+	if (ret < 0) {
+		dev_err(sensehat->dev, "Unable to get sensehat firmware version");
 		return ret;
+	}
 
 	dev_info(sensehat->dev,
-		 "Raspberry Pi Sense HAT firmware version %i\n", ret);
+		 "Raspberry Pi Sense HAT firmware version %i\n", reg);
 
 	sensehat->joystick.pdev = sensehat_client_dev_register(sensehat,
 							       "sensehat-joystick");
@@ -115,11 +131,34 @@ alloc_fail:
 	return ERR_PTR(ret);
 }
 
+static bool sensehat_writeable_register(struct device *dev, unsigned reg)
+{
+	return (SENSEHAT_DISPLAY<=reg &&
+		reg < SENSEHAT_DISPLAY + sizeof(sensehat_fb_t))
+		|| reg==SENSEHAT_EE_WP;
+}
+static bool sensehat_readable_register(struct device *dev, unsigned reg)
+{
+	return (SENSEHAT_DISPLAY<=reg &&
+		reg < SENSEHAT_DISPLAY + sizeof(sensehat_fb_t))
+		|| reg == SENSEHAT_WAI || reg == SENSEHAT_VER
+		|| reg == SENSEHAT_KEYS || reg == SENSEHAT_EE_WP;
+}
+
+static struct regmap_config sensehat_config = {
+	.name = "sensehat",
+	.reg_bits = 8,
+	.val_bits = 8,
+	.writeable_reg = sensehat_writeable_register,
+	.readable_reg = sensehat_readable_register,
+};
+
 int sensehat_get_joystick_state(struct sensehat *sensehat)
 {
-	int ret = i2c_smbus_read_byte_data(sensehat->i2c_client, SENSEHAT_KEYS);
+	unsigned reg;
+	int ret = regmap_read(sensehat->regmap, SENSEHAT_KEYS, &reg);
 
-	return ret < 0 ? ret : ret & 0x1f;
+	return ret < 0 ? ret : reg;
 }
 EXPORT_SYMBOL_GPL(sensehat_get_joystick_state);
 
@@ -127,18 +166,18 @@ int sensehat_update_display(struct sensehat *sensehat)
 {
 	int i, j, ret;
 	struct sensehat_display *display = &sensehat->display;
-	struct {u8 reg, pixel_data[8][3][8]; } msg;
+	sensehat_fb_t pixel_data;
 
-	msg.reg = SENSEHAT_DISPLAY;
 	for (i = 0; i < 8; ++i) {
 		for (j = 0; j < 8; ++j) {
-			msg.pixel_data[i][0][j] = display->gamma[display->vmem[i][j].r];
-			msg.pixel_data[i][1][j] = display->gamma[display->vmem[i][j].g];
-			msg.pixel_data[i][2][j] = display->gamma[display->vmem[i][j].b];
+			pixel_data[i][0][j] = display->gamma[display->vmem[i][j].r];
+			pixel_data[i][1][j] = display->gamma[display->vmem[i][j].g];
+			pixel_data[i][2][j] = display->gamma[display->vmem[i][j].b];
 		}
 	}
 
-	ret = i2c_master_send(sensehat->i2c_client, (u8 *)&msg, sizeof(msg));
+	ret = regmap_bulk_write(sensehat->regmap, SENSEHAT_DISPLAY,
+				pixel_data, sizeof(pixel_data));
 	if (ret < 0)
 		dev_err(sensehat->dev, "Update to 8x8 LED matrix display failed");
 	return ret;

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -16,8 +16,11 @@
 #include <linux/interrupt.h>
 #include <linux/gpio/consumer.h>
 #include <linux/platform_device.h>
+#include <linux/regmap.h>
 
 #include "sensehat.h"
+
+int sensehat_get_joystick_state(struct sensehat *sensehat);
 
 static unsigned char keymap[] = {KEY_DOWN, KEY_RIGHT, KEY_UP, KEY_ENTER, KEY_LEFT,};
 
@@ -102,6 +105,14 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 		return ret;
 	}
 	return 0;
+}
+
+int sensehat_get_joystick_state(struct sensehat *sensehat)
+{
+	unsigned reg;
+	int ret = regmap_read(sensehat->regmap, SENSEHAT_KEYS, &reg);
+
+	return ret < 0 ? ret : reg;
 }
 
 static struct platform_device_id sensehat_joystick_device_id[] = {

--- a/sensehat.h
+++ b/sensehat.h
@@ -61,7 +61,6 @@ enum gamma_preset {
 	GAMMA_PRESET_COUNT,
 };
 
-int sensehat_get_joystick_state(struct sensehat *sensehat);
 int sensehat_update_display(struct sensehat *sensehat);
 
 #endif

--- a/sensehat.h
+++ b/sensehat.h
@@ -14,6 +14,17 @@
 #define __LINUX_MFD_SENSEHAT_H_
 #include <linux/miscdevice.h>
 
+//8x8 display with 3 color channels
+typedef u8 sensehat_fb_t[8][3][8];
+
+#define SENSEHAT_DISPLAY		0x00
+#define SENSEHAT_WAI			0xF0
+#define SENSEHAT_VER			0xF1
+#define SENSEHAT_KEYS			0xF2
+#define SENSEHAT_EE_WP			0xF3
+
+#define SENSEHAT_ID			's'
+
 #define SENSEDISP_IOC_MAGIC 0xF1
 
 #define SENSEDISP_IOGET_GAMMA _IO(SENSEDISP_IOC_MAGIC, 0)

--- a/sensehat.h
+++ b/sensehat.h
@@ -61,6 +61,4 @@ enum gamma_preset {
 	GAMMA_PRESET_COUNT,
 };
 
-int sensehat_update_display(struct sensehat *sensehat);
-
 #endif

--- a/sensehat.h
+++ b/sensehat.h
@@ -23,6 +23,7 @@
 struct sensehat {
 	struct device *dev;
 	struct i2c_client *i2c_client;
+	struct regmap *regmap;
 
 	/* Client devices */
 	struct sensehat_joystick {


### PR DESCRIPTION
This is actually a massive upgrade since it removes the need to export symbols and pollute the kernel namespace, and avoids a lot of cludge needed for sending the display data. (we needed to drop down to raw i2c messages instead of smb to send a big enough packet but then needed to half fake it to look like smb but regmap takes care of all of that behind the scenes). It also moves the functions related to the platform drivers back into their files which I think is probably for the better since it does make the pieces less interdependent.