### PR TITLE
backport changes from patchset v5

### DIFF
--- a/raspberrypi,sensehat.yaml
+++ b/raspberrypi,sensehat.yaml
@@ -9,7 +9,7 @@ maintainers:
   - Mwesigwa Guma <mguma@redhat.com>
   - Joel Savitz <jsavitz@redhat.com>
 
-description: |
+description:
   The Raspberry Pi Sensehat is an addon board originally developed
   for the Raspberry Pi that has a joystick and an 8x8 RGB LED display
   as well as several environmental sensors. It connects via i2c and
@@ -17,23 +17,25 @@ description: |
 
 properties:
   compatible:
-    oneOf:
-      - enum:
-        - raspberrypi,sensehat
-        - rpi,rpisense
+    const: raspberrypi,sensehat
 
   reg:
     items:
       - description: i2c bus address
 
-  keys-int-gpios:
+  interrupts:
     items:
-      - description: gpio pin for joystick interrupt
+      - description: pin number for joystick interrupt
+
+  interrupt-parent:
+    items:
+      - description: gpio pin bank for interrupt pin
 
 required:
   - compatible
   - reg
-  - keys-int-gpios
+  - interrupts
+  - interrupt-parent
 
 additionalProperties: false
 
@@ -46,6 +48,7 @@ examples:
       sensehat@46 {
         compatible = "raspberrypi,sensehat";
         reg = <0x46>;
-        keys-int-gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
+        interrupts = <23 GPIO_ACTIVE_HIGH>;
+        interrupt-parent = <&gpio>;
       };
     };

--- a/sensehat.dtbs
+++ b/sensehat.dtbs
@@ -1,51 +1,44 @@
 /dts-v1/;
+/plugin/;
 
 / {
 	compatible = "brcm,bcm2835";
+};
 
-	fragment@0 {
-		target = <0xffffffff>;
+&i2c1 {
+	#address-cells = <0x01>;
+	#size-cells = <0x00>;
+	status = "okay";
 
-		__overlay__ {
-			#address-cells = <0x01>;
-			#size-cells = <0x00>;
-			status = "okay";
-
-			sensehat@46 {
-				compatible = "raspberrypi,sensehat";
-				reg = <0x46>;
-				keys-int-gpios = <0xffffffff 0x17 0x01>;
-				status = "okay";
-			};
-
-			lsm9ds1-magn@1c {
-				compatible = "st,lsm9ds1-magn";
-				reg = <0x1c>;
-				status = "okay";
-			};
-
-			lsm9ds1-accel6a {
-				compatible = "st,lsm9ds1-accel";
-				reg = <0x6a>;
-				status = "okay";
-			};
-
-			lps25h-press@5c {
-				compatible = "st,lps25h-press";
-				reg = <0x5c>;
-				status = "okay";
-			};
-
-			hts221-humid@5f {
-				compatible = "st,hts221-humid\0st,hts221";
-				reg = <0x5f>;
-				status = "okay";
-			};
-		};
+	sensehat@46 {
+		compatible = "raspberrypi,sensehat";
+		reg = <0x46>;
+		interrupts = <23 1>;
+		interrupt-parent = <&gpio>;
+		status = "okay";
 	};
 
-	__fixups__ {
-		i2c1 = "/fragment@0:target:0";
-		gpio = "/fragment@0/__overlay__/sensehat@46:keys-int-gpios:0";
+	lsm9ds1-magn@1c {
+		compatible = "st,lsm9ds1-magn";
+		reg = <0x1c>;
+		status = "okay";
+	};
+
+	lsm9ds1-accel@6a {
+		compatible = "st,lsm9ds1-accel";
+		reg = <0x6a>;
+		status = "okay";
+	};
+
+	lps25h-press@5c {
+		compatible = "st,lps25h-press";
+		reg = <0x5c>;
+		status = "okay";
+	};
+
+	hts221-humid@5f {
+		compatible = "st,hts221-humid\0st,hts221";
+		reg = <0x5f>;
+		status = "okay";
 	};
 };

--- a/sensehat.h
+++ b/sensehat.h
@@ -14,17 +14,6 @@
 #define __LINUX_MFD_SENSEHAT_H_
 #include <linux/miscdevice.h>
 
-//8x8 display with 3 color channels
-typedef u8 sensehat_fb_t[8][3][8];
-
-#define SENSEHAT_DISPLAY		0x00
-#define SENSEHAT_WAI			0xF0
-#define SENSEHAT_VER			0xF1
-#define SENSEHAT_KEYS			0xF2
-#define SENSEHAT_EE_WP			0xF3
-
-#define SENSEHAT_ID			's'
-
 #define SENSEDISP_IOC_MAGIC 0xF1
 
 #define SENSEDISP_IOGET_GAMMA _IO(SENSEDISP_IOC_MAGIC, 0)
@@ -40,8 +29,6 @@ struct sensehat {
 	struct sensehat_joystick {
 		struct platform_device *pdev;
 		struct input_dev *keys_dev;
-		struct gpio_desc *keys_desc;
-		int keys_irq;
 	} joystick;
 
 	struct sensehat_display {
@@ -50,7 +37,7 @@ struct sensehat {
 		struct mutex rw_mtx;
 		u8 gamma[32];
 		struct {
-			u16 b:5, u:1, g:5, r:5;
+			u16 b : 5, u : 1, g : 5, r : 5;
 		} vmem[8][8];
 	} display;
 };


### PR DESCRIPTION
self explanatory—simply took the code exactly as it was from the kernel tree as of patchset v5 and applied the necessary modifications to get it to compile out of tree (change header to use local path, and add defines to enable the sub devices on a kernel without those config options set)