### PR TITLE
Display rewrite

### DIFF
--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -174,7 +174,7 @@ static long sensehat_display_ioctl(struct file *filp, unsigned int cmd,
 	struct sensehat_display *sensehat_display = &sensehat->display;
 	void __user *user_ptr = (void __user *)arg;
 	u8 temp[GAMMA_SIZE];
-	int ret = 0;
+	int i, ret = 0;
 	bool update = false;
 
 	if (mutex_lock_interruptible(&sensehat_display->rw_mtx))
@@ -207,7 +207,8 @@ static long sensehat_display_ioctl(struct file *filp, unsigned int cmd,
 		break;
 	}
 	if (update) {
-		memcpy(sensehat_display->gamma, temp, GAMMA_SIZE);
+		for(i = 0; i < GAMMA_SIZE; ++i)
+			sensehat_display->gamma[i] = temp[i] & 0x1f;
 		sensehat_update_display(sensehat);
 	}
 	mutex_unlock(&sensehat_display->rw_mtx);

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -148,21 +148,24 @@ static ssize_t sensehat_display_write(struct file *filp, const char __user *buf,
 	struct sensehat *sensehat =
 		container_of(filp->private_data, struct sensehat, display.mdev);
 	struct sensehat_display *sensehat_display = &sensehat->display;
-	u8 temp[VMEM_SIZE];
+	int ret = count;
 
 	if (*f_pos >= VMEM_SIZE)
 		return -EFBIG;
 	if (*f_pos + count > VMEM_SIZE)
 		count = VMEM_SIZE - *f_pos;
-	if (copy_from_user(temp, buf, count))
-		return -EFAULT;
 	if (mutex_lock_interruptible(&sensehat_display->rw_mtx))
 		return -ERESTARTSYS;
-	memcpy(sensehat_display->vmem + *f_pos, temp, count);
+	if (copy_from_user(sensehat_display->vmem + *f_pos, buf, count))
+	{
+		ret = -EFAULT;
+		goto out;
+	}
 	sensehat_update_display(sensehat);
 	*f_pos += count;
+out:
 	mutex_unlock(&sensehat_display->rw_mtx);
-	return count;
+	return ret;
 }
 
 static long sensehat_display_ioctl(struct file *filp, unsigned int cmd,

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -96,10 +96,9 @@ static int sensehat_display_remove(struct platform_device *pdev)
 	return 0;
 }
 
-static loff_t sensehat_display_llseek(struct file *filp, loff_t pos, int whence)
+static loff_t sensehat_display_llseek(struct file *filp, loff_t offset, int whence)
 {
-	loff_t base;
-
+	loff_t base, pos;
 	switch (whence) {
 	case SEEK_SET:
 		base = 0;
@@ -113,10 +112,10 @@ static loff_t sensehat_display_llseek(struct file *filp, loff_t pos, int whence)
 	default:
 		return -EINVAL;
 	}
-	base += pos;
-	if (base < 0 || base >= VMEM_SIZE)
+	pos = base + offset;
+	if (pos < 0 || pos >= VMEM_SIZE)
 		return -EINVAL;
-	filp->f_pos = base;
+	filp->f_pos = pos;
 	return base;
 }
 

--- a/sensehat.h
+++ b/sensehat.h
@@ -36,9 +36,7 @@ struct sensehat {
 		struct miscdevice mdev;
 		struct mutex rw_mtx;
 		u8 gamma[32];
-		struct {
-			u16 b : 5, u : 1, g : 5, r : 5;
-		} vmem[8][8];
+		u8 vmem[192];
 	} display;
 };
 


### PR DESCRIPTION
In this series of commits I perform a significant overhaul on the code in `sensehat-display.c`.
Changes:
 - I fixed bug in `sensehat_display_ioctl` where a user could supply gamma values outside of the range 0-31 sending invalid data to the sensehat. The values are now wrapped mod 32 (i.e. only their 5 lsb are considered)
 - I made a small touch up to the `sensehat_display_llseek` function since I felt like the code could be made a bit more clear / self documenting by renaming a few variables
 - I removed the use of temporary buffers to hold the received data from all calls to `copy_from_userspace` (i.e. those in `sensehat_display_write` and `sensehat_display_ioctl`).
   - This has the potential issue that if a user passes a pointer near the edge of their valid memory region and so some amount of data is able to be copied but the copy faults part way through, then a partial update of the sensehat display will occur as opposed to the previous behavior where an error during `copy_from_userspace` would cause the partial changes to never manifest on the display as the syscall would be scrapped before the partial data was copied from temp into the actual vmem or gamma buffer. It does, however, elide an extraneous copy in the case where there is no error.
 - I replaced the userspace interface for the display driver so that the user just directly manages the values they want for each of the 192 bytes (3 for each pixel) and we do nothing more than relay those changes (after wrapping the values mod 32 and applying gamma) directly to the sensehat. I also updated the tests to reflect this new design.