### PR TITLE
fix bug in full sensehat test

### DIFF
--- a/tests/full_sensehat_test.c
+++ b/tests/full_sensehat_test.c
@@ -74,7 +74,7 @@ typedef union
 	uint16_t combined;
 	struct
 	{
-		uint8_t r:5,g:5,b:5;
+		uint16_t r:5,g:5,b:5;
 	};
 }
 Color;


### PR DESCRIPTION
All the "random" colors being generated, weren't actually properly random.

I noticed that they were always only red / orange / yellow / green and so I started
logging the exact colors. Turns out they would always have a value of zero for
their blue component. This is because of a subtle corner case of C behavior with
bitfields. Since I declared the components as a list of bitfields within a uint8_t
type, the compiler had to make sure none of them crossed a uint8_t boundary. This
meant that each bitfield actually got its own byte since two 5 bit bitfields is
larger than a uint8_t. Switching them to be bitfields within a uint16_t counter-
intutively actually packs them into only 2 bytes instead of three, since now the
compiler can let the bitfields cross the byte boundary (just not the word boundary)
which means that the random uint16_t I was generating and putting into `combined`
would actually overlap all 3 components and properly randomize them.