### PR TITLE
Small fixes and clean ups

### DIFF
--- a/raspberrypi,sensehat.yaml
+++ b/raspberrypi,sensehat.yaml
@@ -27,15 +27,10 @@ properties:
     items:
       - description: pin number for joystick interrupt
 
-  interrupt-parent:
-    items:
-      - description: gpio pin bank for interrupt pin
-
 required:
   - compatible
   - reg
   - interrupts
-  - interrupt-parent
 
 additionalProperties: false
 
@@ -49,6 +44,5 @@ examples:
         compatible = "raspberrypi,sensehat";
         reg = <0x46>;
         interrupts = <23 GPIO_ACTIVE_HIGH>;
-        interrupt-parent = <&gpio>;
       };
     };

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -159,18 +159,21 @@ static long sensehat_display_ioctl(struct file *filp, unsigned int cmd,
 			ret = -EFAULT;
 		break;
 	case SENSEDISP_IORESET_GAMMA:
-		if (arg < GAMMA_PRESET_COUNT)
-			memcpy(sensehat_display->gamma, gamma_presets[arg],
-				GAMMA_SIZE);
-		else
+		if (arg >= GAMMA_PRESET_COUNT)
+		{
 			ret = -EINVAL;
-		break;
+			goto no_update;
+		}
+		memcpy(sensehat_display->gamma, gamma_presets[arg],
+			GAMMA_SIZE);
+		goto no_check;
 	default:
 		ret = -EINVAL;
 		break;
 	}
 	for(i = 0; i < GAMMA_SIZE; ++i)
 		sensehat_display->gamma[i] &= 0x1f;
+no_check:
 	sensehat_update_display(sensehat);
 no_update:
 	mutex_unlock(&sensehat_display->rw_mtx);

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -215,20 +215,18 @@ static int sensehat_display_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	ret = devm_add_action(&pdev->dev, (void *)misc_deregister, &sensehat_display->mdev);
+	if (ret < 0) {
+		dev_err(&pdev->dev,
+			"Could not add misc device to devm\n");
+		return ret;
+	}
+
 	dev_info(&pdev->dev,
 		 "8x8 LED matrix display registered with minor number %i",
 		 sensehat_display->mdev.minor);
 
 	sensehat_update_display(sensehat);
-	return 0;
-}
-
-static int sensehat_display_remove(struct platform_device *pdev)
-{
-	struct sensehat *sensehat = dev_get_drvdata(&pdev->dev);
-	struct sensehat_display *sensehat_display = &sensehat->display;
-
-	misc_deregister(&sensehat_display->mdev);
 	return 0;
 }
 
@@ -242,7 +240,6 @@ MODULE_DEVICE_TABLE(platform, sensehat_display_device_id);
 
 static struct platform_driver sensehat_display_driver = {
 	.probe = sensehat_display_probe,
-	.remove = sensehat_display_remove,
 	.driver = {
 		.name = "sensehat-display",
 	},

--- a/sensehat.dtbs
+++ b/sensehat.dtbs
@@ -15,30 +15,25 @@
 		reg = <0x46>;
 		interrupts = <23 1>;
 		interrupt-parent = <&gpio>;
-		status = "okay";
 	};
 
 	lsm9ds1-magn@1c {
 		compatible = "st,lsm9ds1-magn";
 		reg = <0x1c>;
-		status = "okay";
 	};
 
 	lsm9ds1-accel@6a {
 		compatible = "st,lsm9ds1-accel";
 		reg = <0x6a>;
-		status = "okay";
 	};
 
 	lps25h-press@5c {
 		compatible = "st,lps25h-press";
 		reg = <0x5c>;
-		status = "okay";
 	};
 
 	hts221-humid@5f {
 		compatible = "st,hts221-humid\0st,hts221";
 		reg = <0x5f>;
-		status = "okay";
 	};
 };


### PR DESCRIPTION
these are a series of small commits I picked out from my larger series of changes that will be posted as a follow up PR.

I removed some unneeded stuff from the dtbs and removed some unneeded includes that were a relic of the past.

I addressed the issues that were brought up in the PR about the interrupt-parent property

I made a few changes to sensehat display—I made ioctl skip some unnecessary work in the gamma reset case, and was able to get rid of the `sensehat_display_remove` function by passing off its responsibilities to the devres system.