### PR TITLE
Annihilation

### DIFF
--- a/raspberrypi,sensehat.yaml
+++ b/raspberrypi,sensehat.yaml
@@ -43,7 +43,6 @@ examples:
       sensehat@46 {
         compatible = "raspberrypi,sensehat";
         reg = <0x46>;
-        interrupts = <23 GPIO_ACTIVE_HIGH>;
         display@0 {
           compatible = "raspberrypi,sensehat-display";
           reg = <0x0>;

--- a/raspberrypi,sensehat.yaml
+++ b/raspberrypi,sensehat.yaml
@@ -44,5 +44,14 @@ examples:
         compatible = "raspberrypi,sensehat";
         reg = <0x46>;
         interrupts = <23 GPIO_ACTIVE_HIGH>;
+        display@0 {
+          compatible = "raspberrypi,sensehat-display";
+          reg = <0x0>;
+        };
+        joystick@f2 {
+          compatible = "raspberrypi,sensehat-joystick";
+          reg = <0x0>;
+          interrupts = <23 GPIO_ACTIVE_HIGH>;
+        };
       };
     };

--- a/sensehat-core.c
+++ b/sensehat-core.c
@@ -71,6 +71,7 @@ static int sensehat_probe(struct i2c_client *i2c,
 {
 	int ret;
 	unsigned int reg;
+	struct platform_device *child_dev;
 
 	struct sensehat *sensehat =
 		devm_kzalloc(&i2c->dev, sizeof(*sensehat), GFP_KERNEL);
@@ -113,22 +114,20 @@ static int sensehat_probe(struct i2c_client *i2c,
 		 reg);
 
 #ifdef CONFIG_JOYSTICK_SENSEHAT
-	sensehat->joystick.pdev =
-		sensehat_client_dev_register(sensehat, "sensehat-joystick");
+	child_dev = sensehat_client_dev_register(sensehat, "sensehat-joystick");
 
-	if (IS_ERR(sensehat->joystick.pdev)) {
+	if (IS_ERR(child_dev)) {
 		dev_err(sensehat->dev, "failed to register sensehat-joystick");
-		return PTR_ERR(sensehat->joystick.pdev);
+		return PTR_ERR(child_dev);
 	}
 #endif
 #ifdef CONFIG_SENSEHAT_DISPLAY
 
-	sensehat->display.pdev =
-		sensehat_client_dev_register(sensehat, "sensehat-display");
+	child_dev = sensehat_client_dev_register(sensehat, "sensehat-display");
 
-	if (IS_ERR(sensehat->display.pdev)) {
+	if (IS_ERR(child_dev)) {
 		dev_err(sensehat->dev, "failed to register sensehat-display");
-		return PTR_ERR(sensehat->display.pdev);
+		return PTR_ERR(child_dev);
 	}
 #endif
 

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -48,19 +48,20 @@ static const u8 gamma_presets[][GAMMA_SIZE] = {
 	},
 };
 
-static void sensehat_update_display(struct sensehat *sensehat)
+static void sensehat_update_display(struct sensehat_display *display)
 {
 	int i, ret;
-	struct sensehat_display *display = &sensehat->display;
+	struct regmap *regmap = dev_get_regmap(
+		display->pdev->dev.parent, NULL);
 	u8 temp[VMEM_SIZE];
 
 	for(i = 0; i < VMEM_SIZE; ++i)
 		temp[i] = display->gamma[display->vmem[i] & 0x1f];
 
-	ret = regmap_bulk_write(sensehat->regmap, SENSEHAT_DISPLAY, temp,
+	ret = regmap_bulk_write(regmap, SENSEHAT_DISPLAY, temp,
 				VMEM_SIZE);
 	if (ret < 0)
-		dev_err(sensehat->dev,
+		dev_err(&display->pdev->dev,
 			"Update to 8x8 LED matrix display failed");
 }
 
@@ -90,9 +91,8 @@ static loff_t sensehat_display_llseek(struct file *filp, loff_t offset, int when
 static ssize_t sensehat_display_read(struct file *filp, char __user *buf,
 				     size_t count, loff_t *f_pos)
 {
-	struct sensehat *sensehat =
-		container_of(filp->private_data, struct sensehat, display.mdev);
-	struct sensehat_display *sensehat_display = &sensehat->display;
+	struct sensehat_display *sensehat_display =
+		container_of(filp->private_data, struct sensehat_display, mdev);
 	ssize_t retval = -EFAULT;
 
 	if (*f_pos >= VMEM_SIZE)
@@ -113,9 +113,8 @@ out:
 static ssize_t sensehat_display_write(struct file *filp, const char __user *buf,
 				      size_t count, loff_t *f_pos)
 {
-	struct sensehat *sensehat =
-		container_of(filp->private_data, struct sensehat, display.mdev);
-	struct sensehat_display *sensehat_display = &sensehat->display;
+	struct sensehat_display *sensehat_display =
+		container_of(filp->private_data, struct sensehat_display, mdev);
 	int ret = count;
 
 	if (*f_pos >= VMEM_SIZE)
@@ -129,7 +128,7 @@ static ssize_t sensehat_display_write(struct file *filp, const char __user *buf,
 		ret = -EFAULT;
 		goto out;
 	}
-	sensehat_update_display(sensehat);
+	sensehat_update_display(sensehat_display);
 	*f_pos += count;
 out:
 	mutex_unlock(&sensehat_display->rw_mtx);
@@ -139,9 +138,8 @@ out:
 static long sensehat_display_ioctl(struct file *filp, unsigned int cmd,
 				   unsigned long arg)
 {
-	struct sensehat *sensehat =
-		container_of(filp->private_data, struct sensehat, display.mdev);
-	struct sensehat_display *sensehat_display = &sensehat->display;
+	struct sensehat_display *sensehat_display =
+		container_of(filp->private_data, struct sensehat_display, mdev);
 	void __user *user_ptr = (void __user *)arg;
 	int i, ret = 0;
 
@@ -174,7 +172,7 @@ static long sensehat_display_ioctl(struct file *filp, unsigned int cmd,
 	for(i = 0; i < GAMMA_SIZE; ++i)
 		sensehat_display->gamma[i] &= 0x1f;
 no_check:
-	sensehat_update_display(sensehat);
+	sensehat_update_display(sensehat_display);
 no_update:
 	mutex_unlock(&sensehat_display->rw_mtx);
 	return ret;
@@ -226,7 +224,7 @@ static int sensehat_display_probe(struct platform_device *pdev)
 		 "8x8 LED matrix display registered with minor number %i",
 		 sensehat_display->mdev.minor);
 
-	sensehat_update_display(sensehat);
+	sensehat_update_display(sensehat_display);
 	return 0;
 }
 

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -241,16 +241,17 @@ static int sensehat_display_probe(struct platform_device *pdev)
 
 
 
-static struct platform_device_id sensehat_display_device_id[] = {
-	{ .name = "sensehat-display" },
+static struct of_device_id sensehat_display_device_id[] = {
+	{ .compatible = "raspberrypi,sensehat-display" },
 	{},
 };
-MODULE_DEVICE_TABLE(platform, sensehat_display_device_id);
+MODULE_DEVICE_TABLE(of, sensehat_display_device_id);
 
 static struct platform_driver sensehat_display_driver = {
 	.probe = sensehat_display_probe,
 	.driver = {
 		.name = "sensehat-display",
+		.of_match_table = sensehat_display_device_id,
 	},
 };
 

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -27,10 +27,11 @@ static const unsigned int keymap[] = {
 static irqreturn_t sensehat_joystick_report(int n, void *cookie)
 {
 	int i, error, keys;
-	struct sensehat *sensehat = cookie;
-	struct sensehat_joystick *sensehat_joystick = &sensehat->joystick;
+	struct sensehat_joystick *sensehat_joystick = cookie;
+	struct regmap *regmap = dev_get_regmap(
+		sensehat_joystick->pdev->dev.parent, NULL);
 	unsigned long curr_states, changes;
-	error = regmap_read(sensehat->regmap, SENSEHAT_KEYS, &keys);
+	error = regmap_read(regmap, SENSEHAT_KEYS, &keys);
 	if (error < 0) {
 		dev_err(&sensehat_joystick->pdev->dev,
 			"Failed to read joystick state: %d", error);
@@ -79,7 +80,8 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 
 	error = devm_request_threaded_irq(&pdev->dev, sensehat->i2c_client->irq,
 					NULL, sensehat_joystick_report,
-					IRQF_ONESHOT, "keys", sensehat);
+					IRQF_ONESHOT, "keys",
+					sensehat_joystick);
 
 	if (error) {
 		dev_err(&pdev->dev, "IRQ request failed.\n");

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -16,7 +16,6 @@
 #include <linux/interrupt.h>
 #include <linux/platform_device.h>
 #include <linux/regmap.h>
-#include "sensehat.h"
 
 #define SENSEHAT_KEYS 0xF2
 
@@ -98,16 +97,17 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static struct platform_device_id sensehat_joystick_device_id[] = {
-	{ .name = "sensehat-joystick" },
+static struct of_device_id sensehat_joystick_device_id[] = {
+	{ .compatible = "raspberrypi,sensehat-joystick" },
 	{},
 };
-MODULE_DEVICE_TABLE(platform, sensehat_joystick_device_id);
+MODULE_DEVICE_TABLE(of, sensehat_joystick_device_id);
 
 static struct platform_driver sensehat_joystick_driver = {
 	.probe = sensehat_joystick_probe,
 	.driver = {
 		.name = "sensehat-joystick",
+		.of_match_table = sensehat_joystick_device_id,
 	},
 };
 

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -20,6 +20,12 @@
 
 #define SENSEHAT_KEYS 0xF2
 
+struct sensehat_joystick {
+	struct platform_device *pdev;
+	struct input_dev *keys_dev;
+	unsigned long prev_states;
+};
+
 static const unsigned int keymap[] = {
 	BTN_DPAD_DOWN, BTN_DPAD_RIGHT, BTN_DPAD_UP, BTN_SELECT, BTN_DPAD_LEFT,
 };
@@ -53,9 +59,11 @@ static irqreturn_t sensehat_joystick_report(int n, void *cookie)
 static int sensehat_joystick_probe(struct platform_device *pdev)
 {
 	int error, i;
-	struct sensehat *sensehat = dev_get_drvdata(&pdev->dev);
-	struct sensehat_joystick *sensehat_joystick = &sensehat->joystick;
+	struct sensehat_joystick *sensehat_joystick = devm_kzalloc(&pdev->dev,
+		sizeof(*sensehat_joystick), GFP_KERNEL);
+	struct sensehat *sensehat = platform_get_drvdata(pdev);
 
+	sensehat_joystick->pdev = pdev;
 	sensehat_joystick->keys_dev = devm_input_allocate_device(&pdev->dev);
 	if (!sensehat_joystick->keys_dev) {
 		dev_err(&pdev->dev, "Could not allocate input device.\n");

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -18,6 +18,7 @@
 #include <linux/regmap.h>
 
 #define SENSEHAT_KEYS 0xF2
+#include <linux/of_irq.h>
 
 struct sensehat_joystick {
 	struct platform_device *pdev;
@@ -60,7 +61,6 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 	int error, i;
 	struct sensehat_joystick *sensehat_joystick = devm_kzalloc(&pdev->dev,
 		sizeof(*sensehat_joystick), GFP_KERNEL);
-	struct sensehat *sensehat = platform_get_drvdata(pdev);
 
 	sensehat_joystick->pdev = pdev;
 	sensehat_joystick->keys_dev = devm_input_allocate_device(&pdev->dev);
@@ -85,7 +85,7 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 		return error;
 	}
 
-	error = devm_request_threaded_irq(&pdev->dev, sensehat->i2c_client->irq,
+	error = devm_request_threaded_irq(&pdev->dev, of_irq_get(pdev->dev.of_node,0),
 					NULL, sensehat_joystick_report,
 					IRQF_ONESHOT, "keys",
 					sensehat_joystick);

--- a/sensehat.dtbs
+++ b/sensehat.dtbs
@@ -15,6 +15,15 @@
 		reg = <0x46>;
 		interrupts = <23 1>;
 		interrupt-parent = <&gpio>;
+		display@0 {
+			compatible = "raspberrypi,sensehat-display";
+			reg = <0x0>;
+		};
+		joystick@f2 {
+			compatible = "raspberrypi,sensehat-joystick";
+			reg = <0xf2>;
+			interrupts = <23 1>;
+		};
 	};
 
 	lsm9ds1-magn@1c {

--- a/sensehat.dtbs
+++ b/sensehat.dtbs
@@ -13,7 +13,6 @@
 	sensehat@46 {
 		compatible = "raspberrypi,sensehat";
 		reg = <0x46>;
-		interrupts = <23 1>;
 		interrupt-parent = <&gpio>;
 		display@0 {
 			compatible = "raspberrypi,sensehat-display";

--- a/sensehat.h
+++ b/sensehat.h
@@ -19,12 +19,6 @@
 #define SENSEDISP_IOSET_GAMMA _IO(SENSEDISP_IOC_MAGIC, 1)
 #define SENSEDISP_IORESET_GAMMA _IO(SENSEDISP_IOC_MAGIC, 2)
 
-struct sensehat {
-	struct device *dev;
-	struct i2c_client *i2c_client;
-	struct regmap *regmap;
-};
-
 enum gamma_preset {
 	GAMMA_DEFAULT = 0,
 	GAMMA_LOWLIGHT,

--- a/sensehat.h
+++ b/sensehat.h
@@ -12,7 +12,6 @@
 
 #ifndef __LINUX_MFD_SENSEHAT_H_
 #define __LINUX_MFD_SENSEHAT_H_
-#include <linux/miscdevice.h>
 
 #define SENSEDISP_IOC_MAGIC 0xF1
 
@@ -24,21 +23,6 @@ struct sensehat {
 	struct device *dev;
 	struct i2c_client *i2c_client;
 	struct regmap *regmap;
-
-	/* Client devices */
-	struct sensehat_joystick {
-		struct platform_device *pdev;
-		struct input_dev *keys_dev;
-		unsigned long prev_states;
-	} joystick;
-
-	struct sensehat_display {
-		struct platform_device *pdev;
-		struct miscdevice mdev;
-		struct mutex rw_mtx;
-		u8 gamma[32];
-		u8 vmem[192];
-	} display;
 };
 
 enum gamma_preset {


### PR DESCRIPTION
This is a large bunch of changes, but the end result is the complete annihilation of all things sensehat core.

I started by changing the sub devices to avoid accessing the sensehat struct directly, they could get access to its regmap through the parent child relationship between their device structures.

Then, I moved the child device structures out of the sensehat struct in the .h file and into the .c file for each sub device. The sub devices now allocate their own structures.

I could then add the children devices as nodes to the sensehat device tree and remove almost all the code in core letting `devm_of_platform_register` take care of most of the heavy lifting.

Finally, I was able to use the register info in the device tree to remove the hard coded #define values for them in the .c files