### PR TITLE
Platform irq

### DIFF
--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -200,7 +200,7 @@ static int sensehat_display_probe(struct platform_device *pdev)
 {
 	int ret;
 
-	struct sensehat_display *sensehat_display = devm_kzalloc(&pdev->dev,
+	struct sensehat_display *sensehat_display = devm_kmalloc(&pdev->dev,
 		sizeof(*sensehat_display), GFP_KERNEL);
 
 	sensehat_display->pdev = pdev;

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -222,6 +222,7 @@ static int sensehat_display_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	sensehat_update_display(sensehat_display);
 
 	sensehat_display->mdev = (struct miscdevice){
 		.minor = MISC_DYNAMIC_MINOR,
@@ -241,7 +242,6 @@ static int sensehat_display_probe(struct platform_device *pdev)
 		 "8x8 LED matrix display registered with minor number %i",
 		 sensehat_display->mdev.minor);
 
-	sensehat_update_display(sensehat_display);
 	return 0;
 }
 


### PR DESCRIPTION
Switched implementation of irq request from of_irq to platform_irq, fixed potential race condition in display probe, and removed redundancy in display where VMEM was set to 0s with both kzalloc and memset.  