### PR TITLE
Change userspace format back to RGB565

### DIFF
--- a/tests/full_sensehat_test.c
+++ b/tests/full_sensehat_test.c
@@ -9,7 +9,17 @@
 #include <fcntl.h>
 #include <err.h>
 
-static uint8_t screen[8][3][8];
+typedef union
+{
+	uint16_t combined;
+	struct
+	{
+		uint16_t r:5,g:6,b:5;
+	};
+}
+Color;
+
+static Color screen[8][8];
 
 static int disp_fd, joy_fd;
 
@@ -64,20 +74,8 @@ Point;
 
 static void clear_pixel(Point loc)
 {
-	screen[loc.y][0][loc.x]=0;
-	screen[loc.y][1][loc.x]=0;
-	screen[loc.y][2][loc.x]=0;
+	screen[loc.y][loc.x]=(Color){.combined = 0};
 }
-
-typedef union
-{
-	uint16_t combined;
-	struct
-	{
-		uint16_t r:5,g:5,b:5;
-	};
-}
-Color;
 
 static Color get_random_color(void)
 {
@@ -86,9 +84,7 @@ static Color get_random_color(void)
 
 static void set_pixel(Point loc, Color col)
 {
-	screen[loc.y][0][loc.x]=col.r;
-	screen[loc.y][1][loc.x]=col.g;
-	screen[loc.y][2][loc.x]=col.b;
+	screen[loc.y][loc.x]=col;
 }
 
 typedef enum

--- a/tests/sensehat_display_test.c
+++ b/tests/sensehat_display_test.c
@@ -1,15 +1,15 @@
 #include <err.h>
 #include <stdio.h>
 #include <stdint.h>
-#include <sys/ioctl.h>
 
-static void set(FILE *fp, uint8_t rgb[3])
+static void set(FILE *fp, uint16_t pix)
 {
 	rewind(fp);
-	for(size_t i = 0; i < 8; ++i)
-		for(size_t c = 0; c < 3; ++c)
-			for(size_t j = 0; j < 8; ++j)
-				fputc(rgb[c], fp);
+	for(size_t i = 0; i < 64; ++i)
+	{
+		fputc(pix&0xff,fp);
+		fputc(pix>>8, fp);
+	}
 	fflush(fp);
 }
 
@@ -33,26 +33,17 @@ int main(int argc, char **argv)
 			err(1,"unable to open %s", path);
 	}
 
-	char ***msg = (char**[])
+	char **msg = (char*[]){	"blue1","blue2","blue3","blue4","blue5","blank",
+				"green1","green2","green3","green4","green5",
+				"red1","red2","red3","red4","red5","blank",};
+	for(uint16_t mask = 1; mask != 0; mask <<= 1)
 	{
-		(char *[]){"red1","red2","red3","red4","red5",},
-		(char *[]){"green1","green2","green3","green4","green5",},
-		(char *[]){"blue1","blue2","blue3","blue4","blue5",},
-	};
-	for(int i = 0; i < 3; ++i)
-	{
-		uint8_t channels[3] = {0};
-		channels[i] = 1;
-		for(int j = 0; j < 5; ++j)
-		{
-			set(fp, channels);
-			puts(msg[i][j]);
-			channels[i]<<=1;
-			getchar();
-		}
+		set(fp,mask);
+		puts(*msg++);
+		getchar();
 	}
-	set(fp,(uint8_t[]){0,0,0});
-	puts("blank");
+	set(fp,0);
+	puts(*msg++);
 	getchar();
 	fclose(fp);
 	return 0;


### PR DESCRIPTION
exposing the raw 192 byte format used inside the device is counterintuitive (rgb triples are much easier to understand). Because gamma is now removed and we have previously simplified the logic of updating the display, the slight increase in complexity here is worth it for the added clarity.