### PR TITLE
Remove smb register numbers from the device tree again

### DIFF
--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -26,6 +26,8 @@
 #include <linux/property.h>
 #include "sensehat.h"
 
+#define DISPLAY_SMB_REG 0x00
+
 struct sensehat_display {
 	struct platform_device *pdev;
 	struct miscdevice mdev;
@@ -33,7 +35,6 @@ struct sensehat_display {
 	struct {
 		u16 b : 5, u : 1, g : 5, r : 5;
 	} vmem[8][8];
-	u32 display_register;
 	struct regmap *regmap;
 };
 
@@ -54,7 +55,7 @@ static void sensehat_update_display(struct sensehat_display *display)
 			temp[i][2][j] = display->vmem[i][j].b;
 	}
 
-	ret = regmap_bulk_write(display->regmap, display->display_register, temp,
+	ret = regmap_bulk_write(display->regmap, DISPLAY_SMB_REG, temp,
 				sizeof(temp));
 	if (ret < 0)
 		dev_err(&display->pdev->dev,
@@ -134,13 +135,6 @@ static int sensehat_display_probe(struct platform_device *pdev)
 	memset(sensehat_display->vmem, 0, VMEM_SIZE);
 
 	mutex_init(&sensehat_display->rw_mtx);
-
-	ret = device_property_read_u32(&pdev->dev, "reg",
-		&sensehat_display->display_register);
-	if (ret) {
-		dev_err(&pdev->dev, "Could not read register propery.\n");
-		return ret;
-	}
 
 	sensehat_update_display(sensehat_display);
 

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -18,11 +18,12 @@
 #include <linux/regmap.h>
 #include <linux/property.h>
 
+#define JOYSTICK_SMB_REG 0xf2
+
 struct sensehat_joystick {
 	struct platform_device *pdev;
 	struct input_dev *keys_dev;
 	unsigned long prev_states;
-	u32 joystick_register;
 	struct regmap *regmap;
 };
 
@@ -35,7 +36,7 @@ static irqreturn_t sensehat_joystick_report(int n, void *cookie)
 	int i, error, keys;
 	struct sensehat_joystick *sensehat_joystick = cookie;
 	unsigned long curr_states, changes;
-	error = regmap_read(sensehat_joystick->regmap, sensehat_joystick->joystick_register,
+	error = regmap_read(sensehat_joystick->regmap, JOYSTICK_SMB_REG,
 		&keys);
 	if (error < 0) {
 		dev_err(&sensehat_joystick->pdev->dev,
@@ -84,13 +85,6 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 	error = input_register_device(sensehat_joystick->keys_dev);
 	if (error) {
 		dev_err(&pdev->dev, "Could not register input device.\n");
-		return error;
-	}
-
-	error = device_property_read_u32(&pdev->dev, "reg",
-		&sensehat_joystick->joystick_register);
-	if (error) {
-		dev_err(&pdev->dev, "Could not read register propery.\n");
 		return error;
 	}
 

--- a/sensehat.dtbs
+++ b/sensehat.dtbs
@@ -14,13 +14,11 @@
 		compatible = "raspberrypi,sensehat";
 		reg = <0x46>;
 		interrupt-parent = <&gpio>;
-		display@0 {
+		display {
 			compatible = "raspberrypi,sensehat-display";
-			reg = <0x0>;
 		};
-		joystick@f2 {
+		joystick {
 			compatible = "raspberrypi,sensehat-joystick";
-			reg = <0xf2>;
 			interrupts = <23 1>;
 		};
 	};


### PR DESCRIPTION
Upstream seemed to think this thought exercise in the name of configurability and generalization was a step too far... unlike the possibility of multiple sensehats which is perfectly reasonable :^)