### PR TITLE
backport formating and dtbs/yaml changes from last patchset

### DIFF
--- a/raspberrypi,sensehat-display.yaml
+++ b/raspberrypi,sensehat-display.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+$id: http://devicetree.org/schemas/auxdisplay/raspberrypi,sensehat-display.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Raspberry Pi Sensehat Display
+
+maintainers:
+  - Charles Mirabile <cmirabil@redhat.com>
+  - Mwesigwa Guma <mguma@redhat.com>
+  - Joel Savitz <jsavitz@redhat.com>
+
+description:
+  This device is part of the sensehat multi function device.
+  For more information see ../mfd/raspberrypi,sensehat.yaml.
+
+  This device features a programmable 8x8 RGB LED matrix.
+
+properties:
+  compatible:
+    const: raspberrypi,sensehat-display
+
+required:
+  - compatible
+
+additionalProperties: false

--- a/raspberrypi,sensehat-joystick.yaml
+++ b/raspberrypi,sensehat-joystick.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+$id: http://devicetree.org/schemas/input/raspberrypi,sensehat-joystick.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Raspberry Pi Sensehat Joystick
+
+maintainers:
+  - Charles Mirabile <cmirabil@redhat.com>
+  - Mwesigwa Guma <mguma@redhat.com>
+  - Joel Savitz <jsavitz@redhat.com>
+
+description:
+  This device is part of the sensehat multi function device.
+  For more information see ../mfd/raspberrypi,sensehat.yaml.
+
+  This device features a five button joystick (up, down,left,
+  right, click)
+
+properties:
+  compatible:
+    const: raspberrypi,sensehat-joystick
+
+  interrupts:
+    items:
+      - description: pin number for joystick interrupt
+
+required:
+  - compatible
+  - interrupts
+
+additionalProperties: false

--- a/raspberrypi,sensehat.yaml
+++ b/raspberrypi,sensehat.yaml
@@ -21,16 +21,27 @@ properties:
 
   reg:
     items:
-      - description: i2c bus address
+      - description: i2c device address
 
-  interrupts:
-    items:
-      - description: pin number for joystick interrupt
+  "#address-cells":
+    const: 1
+
+  "#size-cells":
+    const: 0
+
+  "joystick":
+    $ref: ../input/raspberrypi,sensehat-joystick.yaml
+
+  "display":
+    $ref: ../auxdisplay/raspberrypi,sensehat-display.yaml
 
 required:
   - compatible
   - reg
-  - interrupts
+  - "#address-cells"
+  - "#size-cells"
+  - joystick
+  - display
 
 additionalProperties: false
 
@@ -41,15 +52,15 @@ examples:
       #address-cells = <1>;
       #size-cells = <0>;
       sensehat@46 {
+        #address-cells = <1>;
+        #size-cells = <0>;
         compatible = "raspberrypi,sensehat";
         reg = <0x46>;
-        display@0 {
+        display {
           compatible = "raspberrypi,sensehat-display";
-          reg = <0x0>;
         };
-        joystick@f2 {
+        joystick {
           compatible = "raspberrypi,sensehat-joystick";
-          reg = <0x0>;
           interrupts = <23 GPIO_ACTIVE_HIGH>;
         };
       };

--- a/sensehat-display.c
+++ b/sensehat-display.c
@@ -62,7 +62,8 @@ static void sensehat_update_display(struct sensehat_display *display)
 			"Update to 8x8 LED matrix display failed");
 }
 
-static loff_t sensehat_display_llseek(struct file *filp, loff_t offset, int whence)
+static loff_t sensehat_display_llseek(struct file *filp, loff_t offset,
+				      int whence)
 {
 	return fixed_size_llseek(filp, offset, whence, VMEM_SIZE);
 }
@@ -123,8 +124,8 @@ static int sensehat_display_probe(struct platform_device *pdev)
 {
 	int ret;
 
-	struct sensehat_display *sensehat_display = devm_kmalloc(&pdev->dev,
-		sizeof(*sensehat_display), GFP_KERNEL);
+	struct sensehat_display *sensehat_display =
+		devm_kmalloc(&pdev->dev, sizeof(*sensehat_display), GFP_KERNEL);
 
 	sensehat_display->pdev = pdev;
 
@@ -167,7 +168,7 @@ static int sensehat_display_remove(struct platform_device *pdev)
 	return 0;
 }
 
-static struct of_device_id sensehat_display_device_id[] = {
+static const struct of_device_id sensehat_display_device_id[] = {
 	{ .compatible = "raspberrypi,sensehat-display" },
 	{},
 };

--- a/sensehat-joystick.c
+++ b/sensehat-joystick.c
@@ -36,21 +36,22 @@ static irqreturn_t sensehat_joystick_report(int n, void *cookie)
 	int i, error, keys;
 	struct sensehat_joystick *sensehat_joystick = cookie;
 	unsigned long curr_states, changes;
-	error = regmap_read(sensehat_joystick->regmap, JOYSTICK_SMB_REG,
-		&keys);
+
+	error = regmap_read(sensehat_joystick->regmap, JOYSTICK_SMB_REG, &keys);
 	if (error < 0) {
 		dev_err(&sensehat_joystick->pdev->dev,
 			"Failed to read joystick state: %d", error);
 		return IRQ_NONE;
 	}
 	curr_states = keys;
-	bitmap_xor(&changes, &curr_states,
-		&sensehat_joystick->prev_states, ARRAY_SIZE(keymap));
+	bitmap_xor(&changes, &curr_states, &sensehat_joystick->prev_states,
+		   ARRAY_SIZE(keymap));
 
 	for_each_set_bit(i, &changes, ARRAY_SIZE(keymap)) {
-		input_report_key(sensehat_joystick->keys_dev,
-			keymap[i], curr_states & BIT(i));
+		input_report_key(sensehat_joystick->keys_dev, keymap[i],
+				 curr_states & BIT(i));
 	}
+
 	input_sync(sensehat_joystick->keys_dev);
 	sensehat_joystick->prev_states = keys;
 	return IRQ_HANDLED;
@@ -59,8 +60,8 @@ static irqreturn_t sensehat_joystick_report(int n, void *cookie)
 static int sensehat_joystick_probe(struct platform_device *pdev)
 {
 	int error, i, irq;
-	struct sensehat_joystick *sensehat_joystick = devm_kzalloc(&pdev->dev,
-		sizeof(*sensehat_joystick), GFP_KERNEL);
+	struct sensehat_joystick *sensehat_joystick = devm_kzalloc(
+		&pdev->dev, sizeof(*sensehat_joystick), GFP_KERNEL);
 
 	sensehat_joystick->pdev = pdev;
 
@@ -72,9 +73,8 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 		return -ENOMEM;
 	}
 
-	for (i = 0; i < ARRAY_SIZE(keymap); i++) {
+	for (i = 0; i < ARRAY_SIZE(keymap); i++)
 		set_bit(keymap[i], sensehat_joystick->keys_dev->keybit);
-	}
 
 	sensehat_joystick->keys_dev->name = "Raspberry Pi Sense HAT Joystick";
 	sensehat_joystick->keys_dev->phys = "sensehat-joystick/input0";
@@ -95,9 +95,9 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 	}
 
 	error = devm_request_threaded_irq(&pdev->dev, irq, NULL,
-		sensehat_joystick_report,
-		IRQF_ONESHOT, "keys",
-		sensehat_joystick);
+					  sensehat_joystick_report,
+					  IRQF_ONESHOT, "keys",
+					  sensehat_joystick);
 
 	if (error) {
 		dev_err(&pdev->dev, "IRQ request failed.\n");
@@ -107,7 +107,7 @@ static int sensehat_joystick_probe(struct platform_device *pdev)
 	return 0;
 }
 
-static struct of_device_id sensehat_joystick_device_id[] = {
+static const struct of_device_id sensehat_joystick_device_id[] = {
 	{ .compatible = "raspberrypi,sensehat-joystick" },
 	{},
 };

--- a/sensehat.dtbs
+++ b/sensehat.dtbs
@@ -11,35 +11,44 @@
 	status = "okay";
 
 	sensehat@46 {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
 		compatible = "raspberrypi,sensehat";
 		reg = <0x46>;
 		interrupt-parent = <&gpio>;
+		status = "okay";
 		display {
 			compatible = "raspberrypi,sensehat-display";
+			status = "okay";
 		};
 		joystick {
 			compatible = "raspberrypi,sensehat-joystick";
 			interrupts = <23 1>;
+			status = "okay";
 		};
 	};
 
 	lsm9ds1-magn@1c {
 		compatible = "st,lsm9ds1-magn";
 		reg = <0x1c>;
+		status = "okay";
 	};
 
 	lsm9ds1-accel@6a {
 		compatible = "st,lsm9ds1-accel";
 		reg = <0x6a>;
+		status = "okay";
 	};
 
 	lps25h-press@5c {
 		compatible = "st,lps25h-press";
 		reg = <0x5c>;
+		status = "okay";
 	};
 
 	hts221-humid@5f {
 		compatible = "st,hts221-humid\0st,hts221";
 		reg = <0x5f>;
+		status = "okay";
 	};
 };

--- a/sensehat.h
+++ b/sensehat.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-or-later WITH Linux-syscall-note */
 /*
  * Raspberry Pi Sense HAT core driver
  * http://raspberrypi.org
@@ -10,8 +10,8 @@
  * Revised for upstream Linux by: Charles Mirabile, Mwesigwa Guma, Joel Savitz
  */
 
-#ifndef __LINUX_MFD_SENSEHAT_H_
-#define __LINUX_MFD_SENSEHAT_H_
+#ifndef _UAPILINUX_SENSEHAT_H_
+#define _UAPILINUX_SENSEHAT_H_
 
 #define SENSEDISP_IOC_MAGIC 0xF1
 
@@ -20,9 +20,9 @@
 #define SENSEDISP_IORESET_GAMMA _IO(SENSEDISP_IOC_MAGIC, 2)
 
 enum gamma_preset {
-	GAMMA_DEFAULT = 0,
-	GAMMA_LOWLIGHT,
-	GAMMA_PRESET_COUNT,
+	SENSEHAT_GAMMA_DEFAULT = 0,
+	SENSEHAT_GAMMA_LOWLIGHT,
+	SENSEHAT_GAMMA_PRESET_COUNT,
 };
 
 #endif


### PR DESCRIPTION
We forgot to do this before working on the next version, but I was able to insert a commit where we just copied the files from the linux tree using a rebase and resolve the merge conflicts from the subsequent commits to generate this diff as if we had done it beforehand properly

Only substantial diffs are the inclusion of a missing const on the platform id structs that checkpatch caught, and changes to the yaml that we were only able to make in tree.